### PR TITLE
Indexing now works for subdirs, indexes only image-type files.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1062,6 +1062,7 @@ dependencies = [
 name = "file_system"
 version = "0.1.0"
 dependencies = [
+ "db",
  "futures",
  "governor",
  "img_azure",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ serde = { version = "1.0", features = ["derive"] }
 bincode = "1.3.3"
 dioxus = { version = "0.4.0" }
 dioxus-desktop = { version = "0.4.0" }
-tokio = "1.37.0"
+tokio = { version = "1.37.0", features = ["rt", "rt-multi-thread", "macros"] }
 serde_json = "1.0.115"
 trie-rs = "0.2.0"
 once_cell = "1.19.0"

--- a/src/app_props/src/app.rs
+++ b/src/app_props/src/app.rs
@@ -28,7 +28,7 @@ pub fn initialize_embeddings(app: Arc<Mutex<App>>) {
     {
         let mut app = app.lock().unwrap();
         let mut embeddings = app.embeddings.lock().unwrap();
-        embeddings.get_embeddings(r"C:\Users\ikvict\RustroverProjects\file-search\glove.6B.100d.txt");
+        embeddings.get_embeddings(r"C:\Users\ikvict\RustroverProjects\file-search\glove.6B.300d.txt");
         print!("Embeddings initialized\n");
     }
     {

--- a/src/file_system/Cargo.toml
+++ b/src/file_system/Cargo.toml
@@ -13,3 +13,4 @@ reqwest = { version = "0.12.3", features = ["json"] }
 img_azure = { path = "../img_azure" }
 serde_json = "1.0.115"
 tokio = "1.37.0"
+db = { path = "../db"}

--- a/src/file_system/src/dir_walker.rs
+++ b/src/file_system/src/dir_walker.rs
@@ -11,7 +11,7 @@ use futures::stream;
 use futures::stream::StreamExt;
 use serde_json::Value;
 use img_azure::azure_api::*;
-
+use db::database::Database;
 
 pub struct DirWalker {
     dirs: Arc<Mutex<Vec<String>>>,
@@ -121,50 +121,88 @@ impl DirWalker {
     }
 
 
-
-    pub async fn send_requests_for_dir_apply(&self, requests_per_sec: u32, f: impl Fn(Result<AzureResponse, ErrorKind>, PathBuf)) -> Result<(), Box<dyn Error>>{
-
-        let dir = self.dirs.lock().unwrap().pop().unwrap();
-
-        let dir_entries = tokio::fs::read_dir(dir).await?;
-
-
-        let dir_entries_stream = stream::unfold(dir_entries, |mut dir_entries| async {
-            match dir_entries.next_entry().await {
-                Ok(Some(entry)) => Some((entry, dir_entries)),
-                _ => None,
-            }
-        });
-
-        let callback = Arc::new(f);
-
-        println!("Starting processing");
+    pub async fn send_requests_for_dir_apply(&self, db: Arc<Mutex<Option<Database>>>, requests_per_sec: u32, f: impl Fn(Result<AzureResponse, ErrorKind>, PathBuf) + Send + 'static) -> Result<(), Box<dyn Error>> {
+        let dirs = self.dirs.clone();
+        let dirs_arc = Arc::clone(&dirs);
         let current = time::Instant::now();
-        let limiter = Arc::new(RateLimiter::direct(
-            Quota::per_second(NonZeroU32::new(requests_per_sec).unwrap())
-        ));
+        let f = Arc::new(f);
+        let db = db.clone();
+        while let Some(dir) = {
+            let mut dirs = dirs.lock().unwrap();
+            dirs.pop()
+        } {
+            let dir_entries = tokio::fs::read_dir(dir).await?;
 
-        dir_entries_stream.for_each_concurrent(None, |entry| {
-            let limiter = Arc::clone(&limiter);
-
-            let callback = Arc::clone(&callback);
-            async move {
-                limiter.until_ready().await;
-                let path = entry.path();
-                if path.is_file() {
-
-                    let mut request = AzureRequest::new("4d7bd39a70c249eebd19f5b8d62f5d7b", vec!["tags", "caption"]);
-                    request.set_img(path.to_str().unwrap()).unwrap();
-
-                    let response= request.send_request().await.unwrap();
-                    let response_copy = response.json::<Value>().await.unwrap();
-                    let response_struct: Result<AzureResponse, ErrorKind> = AzureResponse::try_from(response_copy.clone());
-                    callback(response_struct, path.clone());
+            let dir_entries_stream = stream::unfold(dir_entries, |mut dir_entries| async {
+                match dir_entries.next_entry().await {
+                    Ok(Some(entry)) => Some((entry, dir_entries)),
+                    _ => None,
                 }
-            }
-        }).await;
+            });
+
+            let callback = f.clone();
+            let limiter = Arc::new(RateLimiter::direct(
+                Quota::per_second(NonZeroU32::new(requests_per_sec).unwrap()),
+            ));
+
+            let db = db.clone();
+            let dirs_arc_clone = Arc::clone(&dirs_arc);
+
+            dir_entries_stream.for_each_concurrent(None, move |entry| {
+                let limiter = Arc::clone(&limiter);
+                let callback = Arc::clone(&callback);
+                let dirs_arc_clone = Arc::clone(&dirs_arc_clone);
+                let db = Arc::clone(&db);
+                let mut db = db.lock().unwrap();
+                let path = entry.path();
+                let mut flag = false;
+                if (path.is_file()) {
+                    if is_image(path.to_str().unwrap()) {
+                        let db = db.as_mut().unwrap();
+                        flag = db.exists_image_by_path(path.to_str().unwrap()).unwrap();
+                    }
+                }
+                async move {
+                    if flag {
+                        return;
+                    }
+                    let path = entry.path();
+                    if path.is_file() {
+                        if !is_image(path.to_str().unwrap()) {
+                            return;
+                        }
+                        let path_str = path.to_str().unwrap();
+
+
+                        limiter.until_ready().await;
+
+                        let mut request = AzureRequest::new("4d7bd39a70c249eebd19f5b8d62f5d7b", vec!["tags", "caption"]);
+                        request.set_img(path_str).unwrap();
+                        let response = request.send_request().await.unwrap();
+                        let response_copy = response.json::<Value>().await.unwrap();
+                        let response_struct: Result<AzureResponse, ErrorKind> = AzureResponse::try_from(response_copy.clone());
+
+                        callback(response_struct, path);
+                    } else if path.is_dir() {
+                        let mut dirs = dirs_arc_clone.lock().unwrap();
+                        dirs.push(path.to_str().unwrap().to_string());
+                    }
+                }
+            }).await;
+        }
 
         println!("Time elapsed: {:?}", current.elapsed());
+        println!("Dirs {:?}", dirs.lock().unwrap());
         Ok(())
     }
+}
+
+fn is_image(path: &str) -> bool {
+    if let Some(ext) = Path::new(path).extension() {
+        return match ext.to_str() {
+            Some("jpg") | Some("jpeg") | Some("png") => true,
+            _ => false,
+        };
+    }
+    false
 }


### PR DESCRIPTION
Indexing now works for subdirs, indexes only image-type files. Doesn't try to save duplicated file.
Image-search fixed bugs with case-sensitive vectorization. Fixed bug when "search-word" was not found in model dictionary